### PR TITLE
Add error handeling when empty username in updateUsername and display…

### DIFF
--- a/Backend/app/controllers/user.controller.js
+++ b/Backend/app/controllers/user.controller.js
@@ -118,6 +118,13 @@ exports.updateUsername = async (req, res) => {
         type: QueryTypes.SELECT
     });
 
+    if (!newUsername) {
+        res.status(404).send({
+            message: "Kein Username gegeben!"
+        })
+        return;
+    }
+
     if (oldUsername[0].username == newUsername) {
         res.status(430).send({
             message: "Username hat sich nicht geändert!"

--- a/Backend/app/controllers/user.controller.js
+++ b/Backend/app/controllers/user.controller.js
@@ -322,7 +322,7 @@ exports.register = (req,res) => {
     let errors= [];
 
     //Überprüfen, ob alle notwendigen Felder ausgefüllt sind
-    if(!username || !email || !password) {
+    if(!username || !email || !password || username.length > 18) {
         errors.push({msg: 'Please fill out all fields'});
     }
 

--- a/Backend/app/controllers/user.controller.js
+++ b/Backend/app/controllers/user.controller.js
@@ -118,7 +118,7 @@ exports.updateUsername = async (req, res) => {
         type: QueryTypes.SELECT
     });
 
-    if (!newUsername) {
+    if (!newUsername || newUsername.length > 18) {
         res.status(404).send({
             message: "Kein Username gegeben!"
         })

--- a/Backend/app/controllers/user.controller.js
+++ b/Backend/app/controllers/user.controller.js
@@ -322,17 +322,13 @@ exports.register = (req,res) => {
     let errors= [];
 
     //Überprüfen, ob alle notwendigen Felder ausgefüllt sind
-    if(!username || !email || !password || username.length > 18) {
+    //Username- und Passwordlänge überprüfen
+    if(!username || !email || !password || username.length > 18 || password.length < 8) {
         errors.push({msg: 'Please fill out all fields'});
     }
 
     //TODO Überprüfen, ob die E-Mail eine E-Mail ist
 
-    //Passwordlänge überprüfen
-    if (password.length < 8) {
-        errors.push({msg: 'Password has to have at least 8 characters'});
-    }
-    //TODO überprüfen, ob Benutzername schon vergeben ist
     if(errors.length > 0) {
         res.json(500, {
             errors,

--- a/Frontend/src/components/usermanagement/SettingsUsername.vue
+++ b/Frontend/src/components/usermanagement/SettingsUsername.vue
@@ -53,7 +53,7 @@ export default {
         sameUsernameError: false,
         rules: {
           required: value => !!value || 'Required.',
-          max: v => v.length <=18 || 'Max 18 characters'
+          max: value => value.length <=18 || 'Max 18 characters'
         },
       }
     },

--- a/Frontend/src/components/usermanagement/SettingsUsername.vue
+++ b/Frontend/src/components/usermanagement/SettingsUsername.vue
@@ -8,11 +8,14 @@
     <p class ="error">{{$t('error.usernameAssigned')}}</p>
   </v-col>
   <v-col v-if="internalError" cols="12">
-    <p class ="error">{{$t('error.internaleError')}}</p>
+    <p class ="error">{{$t('error.internalError')}}</p>
   </v-col>
   <v-col v-if="sameUsernameError" cols="12">
     <p class ="error">{{$t('error.sameUsername')}}</p>
   </v-col>
+    <v-col v-if="incompleteError" cols="12">
+      <p class ="error">{{$t('error.incompleteError')}}</p>
+    </v-col>
   <v-col cols="4">
     <v-text-field
     :rules="[rules.required,rules.max]"
@@ -40,17 +43,19 @@ import {SET_USERNAME} from "../../store/mutations";
 export default {
     name:"SettingsUsername",
     data(){ 
-        return{
-            updatedUsername: false,
-            newUsername: '',
-            usernameAssignedError: false,
-            updated: false,
-            sameUsernameError: false,
-            rules: {
-            required: value => !!value || 'Required.',
-            max: v => v.length <=18 || 'Max 18 characters'
-          },
-        }
+      return{
+        updatedUsername: false,
+        newUsername: '',
+        usernameAssignedError: false,
+        incompleteError: false,
+        internalError: false,
+        updated: false,
+        sameUsernameError: false,
+        rules: {
+          required: value => !!value || 'Required.',
+          max: v => v.length <=18 || 'Max 18 characters'
+        },
+      }
     },
     methods: {
     changeUsername(){
@@ -68,7 +73,7 @@ export default {
             this.$store.commit(SET_USERNAME, this.newUsername);
             }  
       }).catch((error) => {
-          if(error.response && error.response.status == 400){
+          if(error.response && error.response.status == 404){
             this.incompleteError = true;
             this.usernameAssignedError = false;
             this.internalError = false;


### PR DESCRIPTION
Leerer und zu langer username im Backend bei der Registrierung und in den Settingsabgefangen und Fehlermessage im Frontend angezeigen. Passwort Länge wird zusammengefasst mit Not Null Checks und zu langer Username Check im Backend, da die Fehlermeldung im Frontend gleich behandelt wird.